### PR TITLE
Make the analyzer happy by initializing result

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -1028,7 +1028,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
     checkForOpenDatabaseFatal(YES);
 
     NSThread *sourceThread = NSThread.currentThread;
-    __block FCModelSaveResult result;
+    __block FCModelSaveResult result = FCModelSaveFailed;
     __block NSSet *changedFields;
     [g_databaseQueue writeDatabase:^(FMDatabase *db) {
         if (deleted) { result = FCModelSaveNoChanges; return; }


### PR DESCRIPTION
Result is set in all cases, but the analyzer is complaining because he
doesn't know that the block is blocking (pun intended).
This should make him happy without changes to the outcome of this method.
